### PR TITLE
Make mode-line more compact and ease discoverability

### DIFF
--- a/overleaf.el
+++ b/overleaf.el
@@ -1135,7 +1135,7 @@ to the default tooltip text."
          (if overleaf-track-changes
              (overleaf--mode-line-item ", t" "track-changes: on")
            ""))
-      (overleaf--mode-line-item "❌" "not connected"))
+      (overleaf--mode-line-item "" "not connected"))
     (overleaf--mode-line-item ")")))
   (force-mode-line-update t))
 


### PR DESCRIPTION
This PR makes overleaf.el take less space of the limited mode-line space, while (hopefully) display the same amount of information.  Additionally,  it adds a menu and tooltips to the mode-line helping new users to discover the features of overleaf.el.

If I went too far with this, just let me know.  Thanks.

----

* overleaf.el: (overleaf--mode-line): Make it a risky local variable.
(overleaf-menu, overleaf--menu-map): New variables. (overleaf--mode-line-item): New defun.
(overleaf--update-modeline): Create a more compact mode-line with tooltips and a menu.
(overleaf-mode): Do not define a lighter.