### PR TITLE
make it easier to customize webdriver capabilities

### DIFF
--- a/overleaf.el
+++ b/overleaf.el
@@ -750,6 +750,9 @@ The element is then bound to ELEMENT-SYM and the BODY is executed."
            `(:name ,(string-trim name) :value ,(string-trim value) :domain
                    ,cookie-domain)))))))
 
+(defun overleaf--webdriver-make-session ()
+  "Create a webdriver session. Advise this function to control browser capabilities."
+  (make-instance 'webdriver-session))
 
 ;;;; Change Detection
 
@@ -963,7 +966,7 @@ https://github.com/mozilla/geckodriver/releases) to be installed."
      (user-error "Both overleaf-cookies and overleaf-save-cookies need to be set"))
 
    (setq-local overleaf-url url)
-   (let ((session (make-instance 'webdriver-session)))
+   (let ((session (overleaf--webdriver-make-session)))
      (unwind-protect
          (let ((full-cookies (overleaf--get-full-cookies)))
            (webdriver-session-start session)
@@ -1018,7 +1021,7 @@ https://github.com/mozilla/geckodriver/releases) to be installed."
 
 This message will self-destruct in 10 seconds!
 (Just kidding...)")
-   (let ((session (make-instance 'webdriver-session)))
+   (let ((session (overleaf--webdriver-make-session)))
      (unwind-protect
          (progn
            (webdriver-session-start session)


### PR DESCRIPTION
Pulling out the logic for WebDriver session creation makes it easier for end users to override arguments/capabilities to be passed to the browser.
This is probably helpful only for folks with weird setups (like me) and should change nothing for most users.

For example: `geckodriver` searches an OS-specific set of [default locations](https://developer.mozilla.org/en-US/docs/Web/WebDriver/Reference/Capabilities/firefoxOptions#binary_string) for the Firefox binary. This is a very sane default, but it does not find Firefox installed in (insane) places like `$HOME/Applications/Home Manager Apps/Firefox Nightly.app`; this could be fixed with the following advice:
```
(define-advice overleaf--webdriver-make-session (:override () unorthodox-firefox-path)
  (let ((caps (make-instance 'webdriver-capabilities-firefox)))
    (webdriver-capabilities-add caps :binary (expand-file-name "~/Applications/Home Manager Apps/Firefox Nightly.app") t)
    (make-instance 'webdriver-session :requested-capabilities caps)))
```

Thank you for your work on this excellent package!