### PR TITLE
Add command overleaf-list-users

### DIFF
--- a/README.org
+++ b/README.org
@@ -139,7 +139,8 @@ The available keybindings
   - =[prefix] t= - toggle track-changes
   - =[prefix] s= - toggle auto-save
   - =[prefix] b= - browse project
-  - =[prefix] b= - go to the cursor of another user
+  - =[prefix] g= - go to the cursor of another user
+  - =[prefix] l= - list users' cursor positions in an xref buffer
 
 * Troubleshooting
 Rather verbose logging may be enabled by setting ~overleaf-debug~ to ~t~.


### PR DESCRIPTION
Since it is unlikely that lots of users will edit a file in parallel, I don't think this PR will be frequently useful, on the other hand having an overview of the subsections others edit is a fun little feature (but this requires using the %w template character.)

----

This is similar to overleaf-goto-cursor, but it is easier to jump between user-locations with "M-g n" and "M-g p" (next-error, previous-error).

overleaf-user-info-template does not contain which-function info by default, because I think which-function-mode should be customized to be useful for latex files.

* overleaf.el (overleaf-user-info-template): New defcustom. (overleaf--other-users-p, overleaf--format-user-info) (overleaf-list-users): New defuns.
(overleaf-menu): Add overleaf-list-users; fix activation predicate for overleaf-goto-cursor.
(overleaf-mode): Bind "l" to overleaf-list-users.

* README.org (Keybindings): Document the new binding to 'l'; fix keybinding of overleaf-goto-cursor.