### PR TITLE
Refactor overleaf keymap to support dynamic prefix changes

### DIFF
--- a/README.org
+++ b/README.org
@@ -102,7 +102,7 @@ project and file to connect to if the buffer has never been connected to overlea
 If you want to reconnect the same buffer forcibly to another overleaf document, use ~overleaf-find-file~.
 
 If this buffer hasn't been associated
-with an overleaf connection before (i.e.  there are two ways to obtain
+with an overleaf connection before (i.e.
 the ~document-id~ and ~project-id~ aren't set), use ~M-x overleaf-find-file~
 to select a project and file.
 

--- a/overleaf.el
+++ b/overleaf.el
@@ -226,9 +226,6 @@ edited from the overleaf interface.   The download URL will then be of the form
 
 ;;;###autoload
 (eval-and-compile
-  (defcustom overleaf-keymap-prefix "C-c C-o"
-    "The prefix for dotcrafter-mode key bindings."
-    :type 'string)
   (put 'overleaf-auto-save 'safe-local-variable #'booleanp)
   (put 'overleaf-url 'safe-local-variable #'stringp)
   (put 'overleaf-track-changes 'safe-local-variable #'booleanp)
@@ -1679,10 +1676,28 @@ to the default tooltip text."
   (overleaf--update-modeline)
   (setq inhibit-modification-hooks nil))
 
+(defcustom overleaf-keymap-prefix "C-c C-o"
+  "Prefix key for `overleaf-command-map' inside `overleaf-mode'."
+  :type 'key
+  :initialize 'custom-initialize-default
+  :set (lambda (sym val)
+         (defvar overleaf-mode-map) (defvar overleaf-command-map)
+         (keymap-unset overleaf-mode-map (symbol-value sym))
+         (keymap-set overleaf-mode-map val overleaf-command-map)
+         (set-default sym val)))
 
-(defmacro overleaf--key (key function)
-  "Define a mapping of KEY to FUNCTION with the appropriate prefix."
-  `(cons (kbd ,(concat overleaf-keymap-prefix " " key))  #',function))
+(defvar-keymap overleaf-command-map
+  "c" #'overleaf-connect
+  "d" #'overleaf-disconnect
+  "t" #'overleaf-toggle-track-changes
+  "s" #'overleaf-toggle-auto-save
+  "b" #'overleaf-browse-project
+  "g" #'overleaf-goto-cursor
+  "l" #'overleaf-list-users)
+
+(defvar-keymap overleaf-mode-map
+  :doc "Minor-mode map for `overleaf-mode'."
+  overleaf-keymap-prefix overleaf-command-map)
 
 ;;;###autoload
 (define-minor-mode overleaf-mode
@@ -1691,15 +1706,7 @@ Interactively with no argument, this command toggles the mode."
 
   :init-value nil
   :lighter nil ; Use `overleaf--mode-line' instead.
-  :keymap
-  (list
-   (overleaf--key "c" overleaf-connect)
-   (overleaf--key "d" overleaf-disconnect)
-   (overleaf--key "t" overleaf-toggle-track-changes)
-   (overleaf--key "s" overleaf-toggle-auto-save)
-   (overleaf--key "b" overleaf-browse-project)
-   (overleaf--key "g" overleaf-goto-cursor)
-   (overleaf--key "l" overleaf-list-users))
+  :keymap overleaf-mode-map
 
   (if overleaf-mode
       (overleaf--init)


### PR DESCRIPTION
This PR streamlines how the prefix key is handled, following standard practices in built-in Emacs modes (follow.el, outline.el, ...).  The only user-facing difference is that keys are rebound as soon as the prefix key is modified.
