### PR TITLE
fix: require mm-url in overleaf-find-file

### DIFF
--- a/overleaf.el
+++ b/overleaf.el
@@ -1513,8 +1513,8 @@ Optionally prompt for the overleaf server URL."
    (list
     (read-string "Overleaf URL: " (overleaf--url))))
 
-  ;; for mm-url-decode
-  (require 'gnus)
+  (require 'mm-url)
+  (declare-function mm-url-decode-entities-string "mm-url")
   (overleaf-disconnect)
   (setq-local overleaf-url url)
   (setq-local overleaf-project-id nil)


### PR DESCRIPTION
* overleaf.el (overleaf-find-file): Require 'mm-url, so that
mm-url-decode-entities-string is defined.

fixes #9