### PR TITLE
breaking: Remove keymap prefix in overleaf-mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -131,9 +131,23 @@ If you have a font with nerd-font symbol support you can set:
 
 
 ** Keybindings
-The keymap prefix can be customized with ~overleaf-keymap-prefix~ which defaults to ~C-c C-o~.
+To make Overleaf keybindings available in LaTeX buffers, bind a key to ~overleaf-command-map~, like so:
 
-The available keybindings
+- For the built-in ~tex-mode~:
+
+#+begin_src elisp
+(with-eval-after-load 'tex-mode
+  (keymap-set latex-mode-map "C-c o" overleaf-command-map))
+#+end_src
+
+- For [[https://www.gnu.org/software/auctex/manual/auctex/Installation.html#Installation][AUCTeX]]:
+
+#+begin_src elisp
+(with-eval-after-load 'latex
+  (keymap-set LaTeX-mode-map "C-c o" overleaf-command-map))
+#+end_src
+
+The available keybindings are then:
   - =[prefix] c= - (re)-connect
   - =[prefix] d= - disconnect
   - =[prefix] t= - toggle track-changes

--- a/overleaf.el
+++ b/overleaf.el
@@ -1697,16 +1697,12 @@ to the default tooltip text."
   (overleaf--update-modeline)
   (setq inhibit-modification-hooks nil))
 
-(defcustom overleaf-keymap-prefix "C-c #"
-  "Prefix key for `overleaf-command-map' inside `overleaf-mode'."
-  :type 'key
-  :initialize 'custom-initialize-default
-  :set (lambda (sym val)
-         (defvar overleaf-mode-map) (defvar overleaf-command-map)
-         (keymap-unset overleaf-mode-map (symbol-value sym))
-         (keymap-set overleaf-mode-map val overleaf-command-map)
-         (set-default sym val)))
+;;;###autoload
+(make-obsolete-variable 'overleaf-keymap-prefix
+                        "bind `overleaf-command-map' directly (see README)."
+                        "1.1.4")
 
+;;;###autoload
 (defvar-keymap overleaf-command-map
   "c" #'overleaf-connect
   "d" #'overleaf-disconnect
@@ -1716,10 +1712,6 @@ to the default tooltip text."
   "g" #'overleaf-goto-cursor
   "l" #'overleaf-list-users)
 
-(defvar-keymap overleaf-mode-map
-  :doc "Minor-mode map for `overleaf-mode'."
-  overleaf-keymap-prefix overleaf-command-map)
-
 ;;;###autoload
 (define-minor-mode overleaf-mode
   "Toggle Overleaf Connection mode.
@@ -1727,7 +1719,6 @@ Interactively with no argument, this command toggles the mode."
 
   :init-value nil
   :lighter nil ; Use `overleaf--mode-line' instead.
-  :keymap overleaf-mode-map
 
   (if overleaf-mode
       (overleaf--init)


### PR DESCRIPTION
* overleaf.el (overleaf-keymap-prefix): Mark as obsolete.
(overleaf-command-map): Add autoload cookie.
(overleaf-mode-map): Remove variable.
(overleaf-mode): Remove :keymap specification.
* README.org (Keybindings): Describe manual keymap binding for
tex-mode and AUCTeX.

See #16.