### PR TITLE
feat: Add keybinding "f" for overleaf-find-file

### DIFF
--- a/README.org
+++ b/README.org
@@ -153,6 +153,7 @@ The available keybindings are then:
   - =[prefix] t= - toggle track-changes
   - =[prefix] s= - toggle auto-save
   - =[prefix] b= - browse project
+  - =[prefix] f= - find file
   - =[prefix] g= - go to the cursor of another user
   - =[prefix] l= - list users' cursor positions in an xref buffer
 

--- a/overleaf.el
+++ b/overleaf.el
@@ -1709,6 +1709,7 @@ to the default tooltip text."
   "t" #'overleaf-toggle-track-changes
   "s" #'overleaf-toggle-auto-save
   "b" #'overleaf-browse-project
+  "f" #'overleaf-find-file
   "g" #'overleaf-goto-cursor
   "l" #'overleaf-list-users)
 


### PR DESCRIPTION
* overleaf.el (overleaf-command-map): Add "f" keybinding for
overleaf-find-file.
* README.org: Document it.