### PR TITLE
fix: Queue pending edits before processing complicated changes

### DIFF
--- a/overleaf.el
+++ b/overleaf.el
@@ -1052,6 +1052,7 @@ overleaf."
                   (setq overleaf--last-change-end end))
                 (setq-local overleaf--last-change-begin overleaf--before-change-begin))
                (t
+                (overleaf-queue-pending-edit)
                 (let* ((old overleaf--before-change)
                        (final (let* ((kept-length (- (length old) length))
                                      (new-length (- end begin))


### PR DESCRIPTION
* overleaf.el (overleaf--after-change-function): Add call to
'overleaf-queue-pending-edit' in the "complicate change" branch.

Fixes #24.