### PR TITLE
feat: add overleaf-create-file to create new project documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ data
 .projectile*
 
 /overleaf-server
+.nixbox

--- a/README.org
+++ b/README.org
@@ -110,6 +110,12 @@ with an overleaf connection before (i.e.
 the ~document-id~ and ~project-id~ aren't set), use ~M-x overleaf-find-file~
 to select a project and file.
 
+To create a *new* file in the project from Emacs, open (or create) a local
+file and call ~M-x overleaf-create-file~.  This creates the document on the
+Overleaf server and connects the current buffer to it.  The project's root
+folder must be known, which is the case once any buffer has connected to the
+project during the current Emacs session.
+
 The default overleaf instance can be customized by changing the ~overleaf-default-url~
 variable.
 
@@ -175,6 +181,7 @@ The available keybindings are then:
   - =[prefix] s= - toggle auto-save
   - =[prefix] b= - browse project
   - =[prefix] f= - find file
+  - =[prefix] n= - create a new file in the project
   - =[prefix] g= - go to the cursor of another user
   - =[prefix] l= - list users' cursor positions in an xref buffer
 

--- a/overleaf.el
+++ b/overleaf.el
@@ -305,7 +305,7 @@ See `overleaf--edit-queue'.")
 (defvar-local overleaf--mode-line ""
   "Contents of the mode-line indicator.")
 
-(defvar overleaf--ws-url->buffer-table (make-hash-table :test #'equal)
+(defvar overleaf--ws->buffer-table (make-hash-table :test #'eql)
   "A hash table associating web-sockets to buffers.")
 
 (defvar overleaf--buffer nil
@@ -435,7 +435,7 @@ The context window size is configured using `overleaf-context-size'."
 (defsubst overleaf--debug (format-string &rest args)
   "Print a debug message with format string FORMAT-STRING and arguments ARGS."
   (when overleaf-debug
-    (if overleaf--buffer
+    (if (buffer-live-p overleaf--buffer)
         (with-current-buffer overleaf--buffer
           (with-current-buffer (get-buffer-create (format "*overleaf-%s*" overleaf-document-id))
             (setq buffer-read-only nil)
@@ -490,45 +490,47 @@ The context window size is configured using `overleaf-context-size'."
 (defun overleaf--on-open (websocket)
   "Handle the open even of the web-socket WEBSOCKET."
   (let ((overleaf--buffer
-         (gethash (websocket-url websocket) overleaf--ws-url->buffer-table)))
+         (gethash websocket overleaf--ws->buffer-table)))
 
-    (with-current-buffer overleaf--buffer
-      (overleaf--update-modeline)
+    (when (buffer-live-p overleaf--buffer)
+      (with-current-buffer overleaf--buffer
+        (overleaf--update-modeline)
 
-      (add-hook 'after-change-functions #'overleaf--after-change-function nil :local)
-      (add-hook 'before-change-functions #'overleaf--before-change-function nil :local)
-      (add-hook 'kill-buffer-hook #'overleaf-disconnect nil :local)
+        (add-hook 'after-change-functions #'overleaf--after-change-function nil :local)
+        (add-hook 'before-change-functions #'overleaf--before-change-function nil :local)
 
-      (setq-local
-       overleaf--flush-edit-queue-timer
-       (progn
-         (when overleaf--flush-edit-queue-timer
-           (cancel-timer overleaf--flush-edit-queue-timer))
-         (run-with-idle-timer overleaf-flush-interval t
-                              (lambda (buffer)
-                                (with-current-buffer buffer
-                                  (unless overleaf--receiving
-                                    (overleaf--flush-edit-queue buffer))))
-                              overleaf--buffer))))))
+        (setq-local
+         overleaf--flush-edit-queue-timer
+         (progn
+           (when overleaf--flush-edit-queue-timer
+             (cancel-timer overleaf--flush-edit-queue-timer))
+           (run-with-idle-timer overleaf-flush-interval t
+                                (lambda (buffer)
+                                  (when (buffer-live-p buffer)
+                                    (with-current-buffer buffer
+                                      (unless overleaf--receiving
+                                        (overleaf--flush-edit-queue buffer)))))
+                                overleaf--buffer)))))))
 
 (defun overleaf--on-message (ws frame)
   "Handle a message received from websocket WS with contents FRAME."
   (let ((overleaf--buffer
-         (gethash (websocket-url ws) overleaf--ws-url->buffer-table)))
-    (overleaf--debug "Got message %S" frame)
-    (overleaf--parse-message ws (websocket-frame-text frame))))
+         (gethash ws overleaf--ws->buffer-table)))
+    (when (buffer-live-p overleaf--buffer)
+      (overleaf--debug "Got message %S" frame)
+      (overleaf--parse-message ws (websocket-frame-text frame)))))
 
 (defun overleaf--on-close (ws)
   "Handle the closure of the websocket WS."
   (let ((overleaf--buffer
-         (gethash (websocket-url ws) overleaf--ws-url->buffer-table)))
-    (when overleaf--buffer
+         (gethash ws overleaf--ws->buffer-table)))
+    (remhash ws overleaf--ws->buffer-table)
+    (when (buffer-live-p overleaf--buffer)
       (with-current-buffer overleaf--buffer
         (when overleaf--websocket
           (overleaf--message "Websocket for document %s closed." overleaf-document-id)
           (setq-local buffer-read-only nil)
           (cancel-timer overleaf--flush-edit-queue-timer)
-          (remhash (websocket-url ws) overleaf--ws-url->buffer-table)
           (setq-local overleaf--websocket nil)
           (overleaf--update-modeline)
           (unless overleaf--force-close
@@ -667,8 +669,9 @@ The context window size is configured using `overleaf-context-size'."
       (run-with-idle-timer
        1 nil
        (lambda (buffer)
-         (with-current-buffer buffer
-           (overleaf--write-buffer-variables)))
+         (when (buffer-live-p buffer)
+           (with-current-buffer buffer
+             (overleaf--write-buffer-variables))))
        overleaf--buffer)
       (overleaf--update-modeline))))
 
@@ -1539,18 +1542,18 @@ See variable `overleaf-user-info-template' for customization."
           (lambda ()
             (let ((xrefs))
               (maphash (lambda (_ buff)
-                         (message "%S" buff)
-                         (with-current-buffer buff
-                           (maphash
-                            (lambda (id overlay)
-                              (cl-pushnew
-                               (xref-make
-                                (overleaf--format-user-info id overlay)
-                                (xref-make-overleaf-location (overlay-buffer overlay)
-                                                             (overlay-start overlay)))
-                               xrefs))
-                            overleaf--user-positions)))
-                       overleaf--ws-url->buffer-table)
+                         (when (buffer-live-p buff)
+                           (with-current-buffer buff
+                             (maphash
+                              (lambda (id overlay)
+                                (cl-pushnew
+                                 (xref-make
+                                  (overleaf--format-user-info id overlay)
+                                  (xref-make-overleaf-location (overlay-buffer overlay)
+                                                               (overlay-start overlay)))
+                                 xrefs))
+                              overleaf--user-positions))))
+                       overleaf--ws->buffer-table)
               xrefs))))
     (if (overleaf--other-users-p)
         (xref-show-xrefs xref-fn nil)
@@ -1729,26 +1732,24 @@ automatically.  Both these variables will be saved to the buffer."
                 ;; magic value, don't ask me why
                 (setq-local overleaf--sequence-id 2)
 
-                (puthash
-                 (websocket-url
-                  (setq-local overleaf--websocket
-                              (websocket-open
-                               (replace-regexp-in-string
-                                "http" "ws"
-                                (replace-regexp-in-string
-                                 "https" "wss"
-                                 (format "%s/socket.io/1/websocket/%s?projectId=%s&esh=1&ssp=1"
-                                         (overleaf--url) ws-id overleaf-project-id)))
-                               :on-message #'overleaf--on-message
-                               :on-close #'overleaf--on-close
-                               :on-open #'overleaf--on-open
-                               :custom-header-alist `(("Cookie" . ,full-cookies)
-                                                      ("Origin" . ,(overleaf--url))))))
-                 overleaf--buffer
-                 overleaf--ws-url->buffer-table)
+                (setq-local overleaf--websocket
+                            (websocket-open
+                             (replace-regexp-in-string
+                              "http" "ws"
+                              (replace-regexp-in-string
+                               "https" "wss"
+                               (format "%s/socket.io/1/websocket/%s?projectId=%s&esh=1&ssp=1"
+                                       (overleaf--url) ws-id overleaf-project-id)))
+                             :on-message #'overleaf--on-message
+                             :on-close #'overleaf--on-close
+                             :on-open #'overleaf--on-open
+                             :custom-header-alist `(("Cookie" . ,full-cookies)
+                                                    ("Origin" . ,(overleaf--url)))))
+                (puthash overleaf--websocket overleaf--buffer overleaf--ws->buffer-table)
                 (overleaf--update-modeline))
             (overleaf-find-file (overleaf--url)))))
     (error "Please set `overleaf-cookies'")))
+
 
 (defun overleaf--ancestor-file ()
   "Return the file path for the overleaf ancestor backup."
@@ -1773,20 +1774,23 @@ automatically.  Both these variables will be saved to the buffer."
 (defun overleaf-disconnect ()
   "Disconnect from overleaf."
   (interactive)
-  (when overleaf--websocket
-    (overleaf--message "Disconnecting")
-    (maphash
-     (lambda (_ overlay)
-       (delete-overlay overlay))
-     overleaf--user-positions)
-    (setq-local overleaf--force-close t)
-    (setq-local overleaf--edit-queue '())
-    (websocket-close overleaf--websocket)
-    (when overleaf-auto-save
-      (overleaf--save-buffer))
-    (overleaf--save-ancestor)
-    (setq-local overleaf--force-close nil)
-    (remhash overleaf--websocket overleaf--ws-url->buffer-table)))
+  (when (and (boundp 'overleaf--websocket) overleaf--websocket)
+    (let ((ws overleaf--websocket))
+      (overleaf--message "Disconnecting")
+      (maphash
+       (lambda (_ overlay)
+         (delete-overlay overlay))
+       overleaf--user-positions)
+      (setq-local overleaf--force-close t)
+      (setq-local overleaf--edit-queue '())
+      (websocket-close ws)
+      (when overleaf-auto-save
+        (overleaf--save-buffer))
+      (overleaf--save-ancestor)
+      (setq-local overleaf--force-close nil)
+      (remhash ws overleaf--ws->buffer-table)
+      (setq-local overleaf--websocket nil)
+      (overleaf--update-modeline))))
 
 (defun overleaf--mode-line-item (text &rest help-lines)
   "Return a mode-line item diplaying TEXT having a tooltip with HELP-LINES.
@@ -1806,7 +1810,9 @@ to the default tooltip text."
    overleaf--mode-line
    (list
     (overleaf--mode-line-item (if overleaf-use-nerdfont "(: " "(Ovl: "))
-    (if (websocket-openp overleaf--websocket)
+    (if (and (boundp 'overleaf--websocket)
+             overleaf--websocket
+             (websocket-openp overleaf--websocket))
         (list
          (cond ((< overleaf--doc-version 0)
                 (overleaf--mode-line-item (if overleaf-use-nerdfont "⟲" "...") "connecting"))
@@ -1836,6 +1842,7 @@ to the default tooltip text."
                                      '(overleaf--mode-line))))
 
   (overleaf--update-modeline)
+  (add-hook 'kill-buffer-hook #'overleaf-disconnect nil :local)
   (setq inhibit-modification-hooks nil))
 
 ;;;###autoload
@@ -1866,7 +1873,9 @@ Interactively with no argument, this command toggles the mode."
       (overleaf--init)
     (setq-local overleaf--mode-line "")
     (force-mode-line-update t)
-    (overleaf-disconnect)))
+    (overleaf-disconnect)
+    (remove-hook 'kill-buffer-hook #'overleaf-disconnect :local)))
+
 
 
 (provide 'overleaf)

--- a/overleaf.el
+++ b/overleaf.el
@@ -1026,6 +1026,20 @@ PADDING (2 characters by default)."
       (overleaf--flush-edit-queue (current-buffer))
       (setq-local overleaf-track-changes track-changes))))
 
+(defun overleaf--persist-when-connected (buffer &optional attempts)
+  "Persist Overleaf's buffer-local variables to BUFFER once it is connected.
+Polls until `overleaf--connected-p' (for up to ~10 seconds) and then
+writes the file-local variables via `overleaf--write-buffer-variables'.
+ATTEMPTS is the internal retry counter."
+  (let ((attempts (or attempts 0)))
+    (cond
+     ((not (buffer-live-p buffer)))
+     ((with-current-buffer buffer (overleaf--connected-p))
+      (with-current-buffer buffer (overleaf--write-buffer-variables)))
+     ((< attempts 40)
+      (run-with-timer 0.25 nil #'overleaf--persist-when-connected
+                      buffer (1+ attempts))))))
+
 (defun overleaf--save-buffer ()
   "Safely save the buffer."
   (let ((overleaf--is-overleaf-change t))
@@ -1778,7 +1792,8 @@ the project during this session."
           (progn
             (setq-local overleaf-document-id doc-id)
             (overleaf--message "Created \"%s\" (doc %s); connecting..." name doc-id)
-            (overleaf-connect))
+            (overleaf-connect)
+            (overleaf--persist-when-connected (current-buffer)))
         (user-error "Creating \"%s\" failed (HTTP %s): %s"
                     name status (or resp-body "no response"))))))
 

--- a/overleaf.el
+++ b/overleaf.el
@@ -308,6 +308,11 @@ See `overleaf--edit-queue'.")
 (defvar overleaf--ws->buffer-table (make-hash-table :test #'eql)
   "A hash table associating web-sockets to buffers.")
 
+(defvar overleaf--project-root-folders (make-hash-table :test #'equal)
+  "A hash table mapping project ids to their root folder id.
+Populated from the `joinProjectResponse' message and used by
+`overleaf-create-file' to know where to create new documents.")
+
 (defvar overleaf--buffer nil
   "The current overleaf buffer (used in lexical binding).")
 
@@ -354,6 +359,9 @@ recent updates.  It has elements of the form `((from-version
      :help "Connect to overleaf"]
     ["Disconnect" overleaf-disconnect
      :help "Disconnect from overleaf"]
+    ["Create new file" overleaf-create-file
+     :help "Create a new document in the project and connect to it"
+     :active overleaf-project-id]
     ["Toggle auto save" overleaf-toggle-auto-save
      :help "Toggle auto-save on overleaf"]
     ["Toggle track changes" overleaf-toggle-track-changes
@@ -704,6 +712,13 @@ The context window size is configured using `overleaf-context-size'."
                      (plist-get
                       (car (plist-get message :args))
                       :publicId))
+         (when-let* ((pid overleaf-project-id)
+                     (root-id (plist-get
+                               (overleaf--pget
+                                (car (plist-get message :args))
+                                :project :rootFolder 0)
+                               :_id)))
+           (puthash pid root-id overleaf--project-root-folders))
          (unwind-protect
              (unless overleaf-document-id
                (let* ((root
@@ -1672,6 +1687,101 @@ Optionally prompt for the overleaf server URL."
     (setq-local overleaf-document-id nil)
     (overleaf-connect)))
 
+(defun overleaf--fetch-project-meta ()
+  "Fetch the Overleaf project page and extract metadata.
+
+Return a plist of the form (:csrf CSRF-TOKEN :root-folder-id ID).  Either
+value may be nil if it could not be located on the page.  Requires
+`overleaf-project-id' and the cookies to be set."
+  (let* ((cookies (overleaf--get-cookies))
+         (page (plz 'get (format "%s/project/%s" (overleaf--url) overleaf-project-id)
+                 :headers `(("Cookie" . ,cookies)
+                            ("Origin" . ,(overleaf--url))))))
+    (save-match-data
+      (list
+       :csrf
+       (cond
+        ((string-match "name=\"ol-csrfToken\"[^>]*?content=\"\\([^\"]+\\)\"" page)
+         (match-string 1 page))
+        ((string-match "content=\"\\([^\"]+\\)\"[^>]*?name=\"ol-csrfToken\"" page)
+         (match-string 1 page))
+        ((string-match "csrfToken[\"']?[[:space:]]*[:=][[:space:]]*[\"']\\([^\"']+\\)[\"']" page)
+         (match-string 1 page)))
+       :root-folder-id
+       (when (string-match "rootFolder[^_]*?_id[\"']?[[:space:]]*[:=][[:space:]]*[\"']\\([0-9a-f]\\{24\\}\\)" page)
+         (match-string 1 page))))))
+
+(defun overleaf--http-post-json (url cookies csrf body)
+  "POST BODY (a JSON string) to URL with COOKIES and the CSRF token.
+
+Return a cons cell (STATUS . RESPONSE-BODY).  STATUS is the HTTP status
+code, or nil if the request failed before a response was received (in
+which case RESPONSE-BODY holds the error message)."
+  (condition-case err
+      (let ((resp (plz 'post url
+                    :headers `(("Cookie" . ,cookies)
+                               ("Origin" . ,(overleaf--url))
+                               ("X-Csrf-Token" . ,csrf)
+                               ("Content-Type" . "application/json"))
+                    :body body
+                    :as 'response)))
+        (cons (plz-response-status resp) (plz-response-body resp)))
+    (plz-error
+     (let* ((pe (cl-find-if #'plz-error-p (cdr err)))
+            (resp (and pe (plz-error-response pe))))
+       (if resp
+           (cons (plz-response-status resp) (plz-response-body resp))
+         (cons nil (error-message-string err)))))))
+
+;;;###autoload
+(defun overleaf-create-file (name)
+  "Create a new document NAME in the current Overleaf project.
+
+The document is created on the Overleaf server (via the web API) and the
+current buffer is then connected to it (see `overleaf-connect').
+
+Requires `overleaf-cookies' to be set; `overleaf-url' and
+`overleaf-project-id' are prompted for if unset.  The project's root
+folder must be known, which is the case once any buffer has connected to
+the project during this session."
+  (interactive
+   (progn
+     (unless overleaf-cookies
+       (user-error "Variable `overleaf-cookies' is not set (see README)"))
+     (unless overleaf-url
+       (setq-local overleaf-url (read-string "Overleaf URL: " (overleaf--url))))
+     (unless overleaf-project-id
+       (setq-local overleaf-project-id (read-string "Project id: ")))
+     (list (read-string "New file name: "
+                        (and buffer-file-name
+                             (file-name-nondirectory buffer-file-name))))))
+  (let* ((meta (overleaf--fetch-project-meta))
+         (csrf (plist-get meta :csrf))
+         (parent (or (gethash overleaf-project-id overleaf--project-root-folders)
+                     (plist-get meta :root-folder-id))))
+    (unless csrf
+      (user-error "Could not read the CSRF token from %s/project/%s -- are the cookies valid?"
+                  (overleaf--url) overleaf-project-id))
+    (unless parent
+      (user-error "Unknown root folder for project %s -- connect to the project once (`overleaf-connect') and retry"
+                  overleaf-project-id))
+    (pcase-let* ((`(,status . ,resp-body)
+                  (overleaf--http-post-json
+                   (format "%s/project/%s/doc" (overleaf--url) overleaf-project-id)
+                   (overleaf--get-cookies) csrf
+                   (json-serialize `(:name ,name :parentFolderId ,parent))))
+                 (doc-id (and (stringp resp-body)
+                              (save-match-data
+                                (when (string-match "\"_id\"[[:space:]]*:[[:space:]]*\"\\([0-9a-f]\\{24\\}\\)\"" resp-body)
+                                  (match-string 1 resp-body))))))
+      (if (and status (<= 200 status 299) doc-id)
+          (progn
+            (setq-local overleaf-document-id doc-id)
+            (overleaf--message "Created \"%s\" (doc %s); connecting..." name doc-id)
+            (overleaf-connect))
+        (user-error "Creating \"%s\" failed (HTTP %s): %s"
+                    name status (or resp-body "no response"))))))
+
 ;;;###autoload
 (defun overleaf-connect ()
   "Connect current buffer to overleaf.
@@ -1858,6 +1968,7 @@ to the default tooltip text."
   "s" #'overleaf-toggle-auto-save
   "b" #'overleaf-browse-project
   "f" #'overleaf-find-file
+  "n" #'overleaf-create-file
   "g" #'overleaf-goto-cursor
   "l" #'overleaf-list-users)
 

--- a/overleaf.el
+++ b/overleaf.el
@@ -119,6 +119,7 @@ To be used with `overleaf-cookies'.  The Firefox folder should be
 located at `~/.mozilla/firefox/'.  If PROFILE is provided, choose this
 profile.  Otherwise prompt."
   (lambda ()
+
     (setopt overleaf-cache-cookies nil)
     (if (sqlite-available-p)
         (let* ((profile-blocks
@@ -126,11 +127,10 @@ profile.  Otherwise prompt."
                   (insert-file-contents (expand-file-name (concat firefox-folder "/profiles.ini")))
                   (goto-char (point-min))
                   (let ((matches))
-                    (while (re-search-forward "\\[.*\\]\\(\\(?:.\\|\n\\)+?\\)\\[" (point-max) t)
+                    (while (re-search-forward "^\\[.+\\]\n\\(\\(?:.*\n?\\)*?\\)\\(?:^\\[\\|$\\)" (point-max) t)
                       (backward-char)
                       (push (match-string 1) matches))
                     matches)))
-
                (profiles
                 (remq 'nil
                       (mapcar (lambda (block)


### PR DESCRIPTION
## Warning

I created this pull request because I find it useful. I don't know what your
policies are regarding AI-generated code, and I used a lot of assistance from
Claude.

## Summary

Adds an interactive command `overleaf-create-file` that creates a new document
in the current Overleaf project and connects the current buffer to it. This lets
you author a file locally and push it to Overleaf without first creating it in
the web UI.

## Motivation

Today a buffer can only connect to a document that already exists in the project
(the "Select file" prompt is built from the existing `rootFolder`), so adding a
new file means creating it in the browser first. This command closes that gap.

## What it does

- `M-x overleaf-create-file` (bound to `n` in `overleaf-command-map`) prompts for
  a name, creates the document on the server (`POST /project/<id>/doc`), sets
  `overleaf-document-id` to the returned id, and connects the buffer.
- The file-local variables (`overleaf-url`, `overleaf-project-id`,
  `overleaf-document-id`) are written as soon as the connection is established, so
  the new file is bound and persisted immediately.

## Implementation

- `overleaf--project-root-folders` caches each project's root folder id, captured
  from `joinProjectResponse`, and is used as the `parentFolderId` for new docs.
  (The command therefore requires having connected to the project once in the
  session; it errors with a clear message otherwise.)
- `overleaf--fetch-project-meta` reads the CSRF token (`ol-csrfToken`) from the
  project page (and tries the root folder id from the page as a fallback).
- `overleaf--http-post-json` performs the POST and returns `(status . body)` so
  failures surface the server response.
- Menu entry + README updated; new command bound to `n`.

## Testing

Verified against overleaf.com: `POST /project/<id>/doc` with body
`{"name": ..., "parentFolderId": <rootFolderId>}` and an `X-Csrf-Token` header
returns `200` with `{"name": ..., "_id": "<24-hex>"}`, the file appears in the
project tree, and the buffer connects and syncs.

## Notes

- The page scrape for the root folder id isn't present on all instances, hence
  the `joinProjectResponse` cache is the primary source.